### PR TITLE
Next/Prev link for weekly overview of weekly statuses

### DIFF
--- a/app/controllers/weekly_statuses_controller.rb
+++ b/app/controllers/weekly_statuses_controller.rb
@@ -36,6 +36,13 @@ class WeeklyStatusesController < ApplicationController
 
   def by_week
     @statuses = WeeklyStatus.by_week(params[:week]).recent
+    if params[:week].to_i > 1 && WeeklyStatus.statuses_in_previous_week(params[:week]).count > 0
+      @previous_week_statuses = params[:week].to_i - 1
+    end
+    count_cw = Date.today.end_of_year.beginning_of_week.strftime("%W").to_i
+    if params[:week].to_i < count_cw && WeeklyStatus.statuses_in_next_week(params[:week]).count > 0
+      @next_week_statuses = params[:week].to_i + 1
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/weekly_status.rb
+++ b/app/models/weekly_status.rb
@@ -33,9 +33,8 @@ class WeeklyStatus < ActiveRecord::Base
   end
 
   def self.by_week(week)
-    start_time = (Time.now.beginning_of_year + week.to_i.weeks).beginning_of_week
-    where('created_at >= :start AND created_at <= :end',
-      { :start => start_time, :end => start_time.end_of_week })
+    week_date = Time.now.beginning_of_year + week.to_i.weeks
+    by_week_with_date(week_date)
   end
 
   def self.search(query)
@@ -50,4 +49,21 @@ class WeeklyStatus < ActiveRecord::Base
   def regenerate_html
     self.status_html = md_to_html(status)
   end
+
+  def self.statuses_in_previous_week(current_week)
+    week_date = Time.now.beginning_of_year + current_week.to_i.weeks - 1.week
+    by_week_with_date(week_date)
+  end
+
+  def self.statuses_in_next_week(current_week)
+    week_date = Time.now.beginning_of_year + current_week.to_i.weeks + 1.week
+    by_week_with_date(week_date)
+  end
+
+  private
+  def self.by_week_with_date(date_in_week)
+    where('created_at >= :start AND created_at <= :end',
+          { :start => date_in_week.beginning_of_week, :end => date_in_week.end_of_week })
+  end
+
 end

--- a/app/views/weekly_statuses/by_week.html.erb
+++ b/app/views/weekly_statuses/by_week.html.erb
@@ -2,3 +2,20 @@
 <h1><%= "Alle Wochenstatus für KW #{params[:week]}" %></h1>
 
 <%= render @statuses %>
+
+<% if @previous_week_statuses || @next_week_statuses %>
+<div class="pagination">
+  <ul>
+<% if @previous_week_statuses %>
+    <li class="previous_page">
+      <%= link_to raw("&lsaquo;"), weekly_statuses_by_week_path(:week => @previous_week_statuses.to_s.rjust(2,'0')) %>
+    </li>
+<% end %>
+<% if @next_week_statuses %>
+    <li class="next_page">
+      <%= link_to raw("&rsaquo;"), weekly_statuses_by_week_path(:week => @next_week_statuses.to_s.rjust(2,'0')) %>
+    </li>
+<% end %>
+  </ul>
+</div>
+<% end %>


### PR DESCRIPTION
There is a link for all statuses of this week.
Displaying links for the week before/after could make sense.
