### PR TITLE
synchronization with external user registry 

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,8 +21,9 @@ class CommentsController < ApplicationController
     respond_to do |format|
       format.html do
         @comments = @comments.order("id DESC")
-        if @author = params[:author]
-          @comments = @comments.where(:author => params[:author])
+        if author = params[:author]
+          @author = User.find_by_handle(author).name || author
+          @comments = @comments.where(:author => author)
           render "comments/index/by_author"
         else
           @comments = @comments.page(params[:page]).per(40)

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -18,9 +18,7 @@ class EntriesController < ApplicationController
 
   def index
     @blog = Blog.find(params[:blog_id])
-    @entries = Entry.includes(:tags)
-                    .where(:blog_id => @blog.id).order('id DESC')
-
+    @entries = Entry.where(:blog_id => @blog.id).order('id DESC')
     respond_to do |format|
       format.html { @entries = @entries.page(params[:page]) }
       format.atom

--- a/app/controllers/weekly_statuses_controller.rb
+++ b/app/controllers/weekly_statuses_controller.rb
@@ -15,12 +15,6 @@
 class WeeklyStatusesController < ApplicationController
   def index
     @statuses = WeeklyStatus.recent.page(params[:page])
-    handles = @statuses.map(&:author)
-    @users = User.select("handle", "name").where(handle: handles).
-        inject({}) do |memo, user|
-      memo[user.handle] = user.name
-      memo
-    end
 
     respond_to do |format|
       format.html

--- a/app/controllers/weekly_statuses_controller.rb
+++ b/app/controllers/weekly_statuses_controller.rb
@@ -15,6 +15,12 @@
 class WeeklyStatusesController < ApplicationController
   def index
     @statuses = WeeklyStatus.recent.page(params[:page])
+    handles = @statuses.map(&:author)
+    @users = User.select("handle", "name").where(handle: handles).
+        inject({}) do |memo, user|
+      memo[user.handle] = user.name
+      memo
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,16 +15,23 @@ class Comment < ActiveRecord::Base
   include MarkdownExtension
   include AuthorExtension
 
+  default_scope { includes(:user) }
+
   attr_accessible :content
 
   validates :content, :owner_id, :owner_type, :presence => true
 
   belongs_to :owner, :polymorphic => true
+  has_one :user, :primary_key => "author", :foreign_key => "handle"
 
   before_save :regenerate_html
 
   def self.search(query)
     where('content LIKE ?', "%#{query}%")
+  end
+
+  def author_name
+    user ? user.name : author
   end
 
   def regenerate_html

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -18,6 +18,7 @@ class Entry < ActiveRecord::Base
   include MarkdownExtension
   include AuthorExtension
 
+  default_scope { includes(:user, :tags) }
   scope :by_date, -> { order("created_at DESC") }
 
   attr_accessible :title, :progress, :plans, :problems, :tag_list
@@ -25,6 +26,7 @@ class Entry < ActiveRecord::Base
   validates :title, :progress, :blog_id, :presence => true
 
   belongs_to :blog
+  has_one :user, :primary_key => "author", :foreign_key => "handle"
   has_many :comments, :as => :owner, :dependent => :destroy
 
   def self.search(query)
@@ -35,6 +37,10 @@ class Entry < ActiveRecord::Base
   end
 
   before_save :regenerate_html
+
+  def author_name
+    user ? user.name : author
+  end
 
   def regenerate_html
     self.progress_html = md_to_html(progress) if progress

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # Copyright 2014 innoQ Deutschland GmbH
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class ApplicationController < ActionController::Base
-  protect_from_forgery
-  before_action :set_user
-  before_action :sync_users
-
-  protected
-
-  def sync_users
-    UserSync.start if Random.rand > 0.8 # no need to check every time
-  end
-
-  def set_user
-    @user = request.headers['REMOTE_USER'] || 'guest'
-  end
+class User < ActiveRecord::Base
+  attr_accessible :handle, :name
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,5 +14,7 @@
 # limitations under the License.
 
 class User < ActiveRecord::Base
+  default_scope { select([:name]) } # everything else is metadata
+
   attr_accessible :handle, :name
 end

--- a/app/models/weekly_status.rb
+++ b/app/models/weekly_status.rb
@@ -48,6 +48,10 @@ class WeeklyStatus < ActiveRecord::Base
     "Wochenstatus KW #{timestamp.strftime('%V')} von #{author}"
   end
 
+  def author_name(user_index)
+    user_index[author] || author
+  end
+
   def regenerate_html
     self.status_html = md_to_html(status) if status
   end

--- a/app/models/weekly_status.rb
+++ b/app/models/weekly_status.rb
@@ -17,8 +17,11 @@ class WeeklyStatus < ActiveRecord::Base
   include MarkdownExtension
   include AuthorExtension
 
+  default_scope { includes(:user) }
+
   attr_accessible :status, :status_html
 
+  has_one :user, :primary_key => "author", :foreign_key => "handle"
   has_many :comments, :as => :owner, :dependent => :destroy
 
   validates :status, :presence => true
@@ -46,6 +49,10 @@ class WeeklyStatus < ActiveRecord::Base
   def title
     timestamp = created_at? ? created_at : Time.now
     "Wochenstatus KW #{timestamp.strftime('%V')} von #{author}"
+  end
+
+  def author_name
+    user ? user.name : author
   end
 
   def regenerate_html

--- a/app/models/weekly_status.rb
+++ b/app/models/weekly_status.rb
@@ -48,10 +48,6 @@ class WeeklyStatus < ActiveRecord::Base
     "Wochenstatus KW #{timestamp.strftime('%V')} von #{author}"
   end
 
-  def author_name(user_index)
-    user_index[author] || author
-  end
-
   def regenerate_html
     self.status_html = md_to_html(status) if status
   end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -1,3 +1,18 @@
+# encoding: UTF-8
+# Copyright 2014 innoQ Deutschland GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "net/http"
 require "uri"
 

--- a/app/services/user_sync.rb
+++ b/app/services/user_sync.rb
@@ -36,7 +36,7 @@ class UserSync
     userlist = retrieve(url, username, password)
     return false unless userlist
 
-    users = User.all.inject({}) do |memo, user|
+    users = User.select("id", "handle", "name").inject({}) do |memo, user|
       memo[user.handle] = user
       memo
     end

--- a/app/services/user_sync.rb
+++ b/app/services/user_sync.rb
@@ -1,0 +1,76 @@
+# encoding: UTF-8
+# Copyright 2014 innoQ Deutschland GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "net/http"
+require "uri"
+
+class UserSync
+
+  def self.start
+    url = ENV["IBLOG_USERLIST_URL"]
+    return false unless url
+    username = ENV["IBLOG_USERLIST_USERNAME"]
+    password = ENV["IBLOG_USERLIST_PASSWORD"]
+
+    # use meta user to store timestamp of last sync - hacky, but effective
+    meta_handle = "LAST_SYNC"
+    meta_user = User.select("id", "updated_at").find_by_handle(meta_handle)
+    if meta_user
+      return unless (Time.now - meta_user.updated_at) / 3600 > 3 # every three hours
+    else
+      meta_user = User.create(handle: meta_handle)
+    end
+
+    userlist = retrieve(url, username, password)
+    return false unless userlist
+
+    users = User.all.inject({}) do |memo, user|
+      memo[user.handle] = user
+      memo
+    end
+
+    transform(userlist) do |handle, name|
+      user = users[handle] || User.new(handle: handle)
+      user.update(name: name) # XXX: inefficient; use bulk transaction?
+    end
+
+    meta_user.touch
+  end
+
+  def self.transform(userlist)
+    userlist["members"].each do |username, details|
+      name = details["displayName"]
+      yield username, name if name
+    end
+  end
+
+  def self.retrieve(url, username, password)
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.scheme == "https"
+
+    req = Net::HTTP::Get.new(uri.request_uri)
+    req.basic_auth(username, password) if username && password
+
+    http.read_timeout = 1
+    begin
+      res = http.request(req)
+      return JSON.parse(res.body)
+    rescue
+      return nil
+    end
+  end
+
+end

--- a/app/views/comments/_show.html.erb
+++ b/app/views/comments/_show.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= avatar(comment.author) %><span class="author"><%= comment.author %></span>
+  <%= avatar(comment.author) %><span class="author"><%= comment.author_name %></span>
   <% if 1 == this_is_preview %>
     <span class="label label-info">Vorschau</span>
   <% else %>

--- a/app/views/comments/index.atom.builder
+++ b/app/views/comments/index.atom.builder
@@ -6,7 +6,7 @@ atom_feed do |feed|
 
   @comments.each do |comment|
     feed.entry(comment, :url => comment_owner_url(comment)) do |entry|
-      entry.title "Kommentar von #{comment.author} zu #{comment.owner.title}"
+      entry.title "Kommentar von #{comment.author_name} zu #{comment.owner.title}"
       entry.summary :type => "html" do |html|
         html.cdata! raw(comment.content_html)
       end
@@ -14,7 +14,7 @@ atom_feed do |feed|
         html.cdata! raw(comment.content_html)
       end
       entry.author do |author|
-        author.name comment.author
+        author.name comment.author_name
       end
     end
   end

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -33,7 +33,7 @@
 
   <% unless @preview %>
     <ul class="breadcrumb entry-meta">
-      <li><%= avatar(entry.author) %><%= link_to entry.author, blog_entries_by_author_path(:author => entry.author) %></li>
+      <li><%= avatar(entry.author) %><%= link_to entry.author_name, blog_entries_by_author_path(:author => entry.author) %></li>
       <li>Erstellt am <%= l entry.created_at, :format => :short %></li>
       <% if entry.created_at != entry.updated_at %>
         <li>Geändert am <%= l entry.updated_at, :format => :short %></li>

--- a/app/views/entries/index.atom.builder
+++ b/app/views/entries/index.atom.builder
@@ -14,7 +14,7 @@ atom_feed do |feed|
         html.cdata! render("entry_cdata.html", :entry => blog_entry)
       end
       entry.author do |author|
-        author.name blog_entry.author
+        author.name blog_entry.author_name
         author.uri blog_entries_by_author_url(blog_entry.author)
       end
     end

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -6,7 +6,11 @@
       <%= @blog.name %> von <%= @blog.owner %>
     <% else %>
       <%= content_for :title, "Alle Einträge in allen Blogs" %>
-      für alle Blogs <% if params[:author] %>von <%= params[:author] %><%= content_for :title, " von #{params[:author]}" %><% end %>
+      für alle Blogs
+      <% if @author %>
+      von <%= @author %>
+      <%= content_for :title, " von #{@author}" %>
+      <% end %>
     <% end %>
   </small>
 </h1>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -1,5 +1,14 @@
 <h2>Server</h2>
 
+<h3>Nutzerdatenbank</h3>
+
+<dl class="dl-horizontal">
+  <dt>Gesamtzahl</dt>
+  <dd><%= User.count %></dd>
+  <dt>zuletzt synchronisiert</dt>
+  <dd><%= User.select("id", "updated_at").find_by_handle("LAST_SYNC").updated_at %></dd>
+</dl>
+
 <h3>Log (Letzte 50 Einträge)</h3>
 
 <pre>

--- a/app/views/weekly_statuses/_weekly_status.html.erb
+++ b/app/views/weekly_statuses/_weekly_status.html.erb
@@ -14,7 +14,7 @@
 
   <% unless @preview %>
     <ul class="breadcrumb entry-meta">
-      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author, weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
+      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author_name, weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
       <li>
         Erstellt am
         <%= link_to l(weekly_status.created_at, :format => :long), weekly_status_path(weekly_status) %>

--- a/app/views/weekly_statuses/_weekly_status.html.erb
+++ b/app/views/weekly_statuses/_weekly_status.html.erb
@@ -14,7 +14,7 @@
 
   <% unless @preview %>
     <ul class="breadcrumb entry-meta">
-      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author_name(@users), weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
+      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author, weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
       <li>
         Erstellt am
         <%= link_to l(weekly_status.created_at, :format => :long), weekly_status_path(weekly_status) %>

--- a/app/views/weekly_statuses/_weekly_status.html.erb
+++ b/app/views/weekly_statuses/_weekly_status.html.erb
@@ -14,7 +14,7 @@
 
   <% unless @preview %>
     <ul class="breadcrumb entry-meta">
-      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author, weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
+      <li><%= avatar(weekly_status.author) %><%= link_to weekly_status.author_name(@users), weekly_statuses_by_author_path(:author => weekly_status.author) %></li>
       <li>
         Erstellt am
         <%= link_to l(weekly_status.created_at, :format => :long), weekly_status_path(weekly_status) %>

--- a/app/views/weekly_statuses/index.atom.builder
+++ b/app/views/weekly_statuses/index.atom.builder
@@ -14,7 +14,7 @@ atom_feed do |feed|
         html.cdata! status.status_html
       end
       entry.author do |author|
-        author.name status.author
+        author.name status.author_name
         author.uri weekly_statuses_by_author_path(status.author)
       end
     end

--- a/db/migrate/20151020072813_create_users.rb
+++ b/db/migrate/20151020072813_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :handle
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
this is required to display authors' full names - see commit messages for details

this is work in progress and not yet ready to be merged: 048e2532d4e55c4a13abad73f9c46c0634794f83 illustrates that we probably want to properly associate posts (`Entry` / `WeeklyStatus` / `Comment`) with the respective `User` (i.e. create model relationships)

any volunteers for that part? /cc @mjansing @mrreynolds @aknrdureegaesr 