### PR TITLE
Documentation improvement.  Better names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/innoq/iBlog.svg?branch=master)](https://travis-ci.org/innoq/iBlog)
 
 Simple internal blogging/PPP solution, originally developed by @stilkov and @pgh.
-iBlog is currently maintained by @mrreynolds.
+iBlog is currently maintained by @mjansing.
 
 ## Security note
 
@@ -23,3 +23,48 @@ attacks. If you don't trust your authors, don't use this software.
 ## Contributing
 
 Please use pull requests.
+
+## Interface to the rest of the world
+
+### Auth
+
+iBlog will look for (and blindly trust) the `REMOTE_USER`
+HTTP header.  The content of this header is the name of the user
+doing the particular request.  It is assumed that iBlog is
+deployed behind some reverse proxy that duely authenticates
+users, sets this header, and makes sure nobody from the outside
+can set it.  If a request hits iBlog without `REMOTE_USER` set, the
+hard-coded username `guest` is used, which is convenient for
+local testing on a development machine.
+
+### Naveed
+
+iBlog provides Atom feeds for its content.  Some folks prefer
+email (or short text messages or whatever), in particular, when
+some new comment appears regarding some discussion they took part
+in earlier.
+
+iBlog does not send out such notifications itself, but leaves that job
+to [Naveed](https://github.com/innoq/naveed) (or any other service
+presenting the same interface as explained below).
+
+Whenever a new comment appears, iBlog checks whether the
+environment variable `IBLOG_NAVEED_URI` and `IBLOG_NAVEED_TOKEN`
+both exist.  When one of them doesn't, nothing happens and all is
+well (which may be what you want in your development environment
+if you're up to different things).  If both do exist, a POST is
+attempted to the `IBLOG_NAVEED_URI` (assumed to be HTTPS (or, if
+you must, HTTP)).  That POST has headers (among others)
+
+    Content-Type: application/x-www-form-urlencoded
+    Authorization: Bearer xxx
+
+(where xxx is replaced with the `IBLOG_NAVEED_TOKEN` content) and
+the content form has the text field `sender`, one or more
+`recipient`, a `subject` and, finally, a `body`.  If you can't
+already guess what those are, let us mention that `sender` and
+`recipient` are whatever iBlog received in the `REMOTE_USER`
+headers (it's Naveed's job to figure out actual contact points).
+
+During unavailability of the Naveed service, update notifications
+are lost.

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 # Copyright 2014 innoQ Deutschland GmbH
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,7 +177,7 @@ neuer Kommentar von #{author}:
 """
     EOS
 
-    Notifier.dispatch(author, users, "[iBlog] #{subject}", body)
+    NaveedNotifier.dispatch(author, users, "[iBlog] #{subject}", body)
   end
 
   def return_path(owner, comment = nil)

--- a/app/services/naveed_notifier.rb
+++ b/app/services/naveed_notifier.rb
@@ -1,10 +1,14 @@
 require "net/http"
 require "uri"
 
-class Notifier
+class NaveedNotifier
 
   def self.dispatch(sender, recipients, subject, body)
-    naveed = ENV["IBLOG_NAVEED_URL"]
+    naveed = ENV["IBLOG_NAVEED_URI"]
+
+    # Deprecated, remove when changed on production host:
+    naveed = ENV["IBLOG_NAVEED_URL"] unless naveed
+
     token = ENV["IBLOG_NAVEED_TOKEN"]
     return false unless naveed && token
 


### PR DESCRIPTION
* @mrreynolds handed maintenance over to @mjansing (and it's fine with him to have this noted here, I asked him).
* In my opinion, we should document the interfaces of iBlog to other stuff. Here's a start at that.  In particular, I was puzzled what a `Notifier` might be. So, besides documenting what it does in the README, I also gave it a more specific name.
* `URL` is old-fashioned and even deprecated, we should call this `URI` now.