### PR TITLE
Add authors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,10 +28,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_author
-    @author = Author.find_by_handle(@user)
-    if ! @author
-      @author = Author.new(handle: @user, name: @user)
-      @author.save
-    end
+    @author = Author.for_handle(@user)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,9 +22,13 @@ class CommentsController < ApplicationController
       format.html do
         @comments = @comments.order("id DESC")
         if author = params[:author]
-          @author = User.find_by_handle(author).name || author
-          @comments = @comments.where(:author => author)
-          render "comments/index/by_author"
+          @author = Author.find_by_handle(author)
+          if @author
+            @comments = @comments.where(:author => @author)
+            render "comments/index/by_author"
+          else
+            render plain: "No comment by #{author} found.", status: 404
+          end
         else
           @comments = @comments.page(params[:page]).per(40)
           render "comments/index/all"

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -14,9 +14,14 @@
 class StatusController < ApplicationController
   def index
     @headers = request.headers
-    ["HTTP_AUTHORIZATION", "action_dispatch.secret_key_base", "action_dispatch.secret_token", "PASSENGER_CONNECT_PASSWORD"].each do |k|
-      @headers[k] = "*REMOVED*" if @headers[k].present?
+    headers_to_be_removed =  ["HTTP_AUTHORIZATION",
+                              "action_dispatch.secret_key_base",
+                              "action_dispatch.secret_token",
+                              "PASSENGER_CONNECT_PASSWORD"]
+    headers_to_be_removed.each do |header|
+      @headers[header] = "*REMOVED*" if @headers[header].present?
     end
     @log = `tail -n 50 #{Rails.root.join('log', "#{Rails.env}.log")}`
+    @author_count = Author.count
   end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -19,7 +19,7 @@ class Author < ActiveRecord::Base
   # Find or construct an appropriate author, given a handle
   def self.for_handle(handle)
     author = Author.find_by_handle handle
-    if ! author
+    unless author
       author = Author.new(handle: handle, name: handle)
       author.save
     end

--- a/app/views/comments/index/by_author.html.erb
+++ b/app/views/comments/index/by_author.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :title, "Alle Kommentare von #{@author}" %>
-<h1>Alle Kommentare von <%= @author %></h1>
+<%= content_for :title, "Alle Kommentare von #{@author.name}" %>
+<h1>Alle Kommentare von <%= @author.name %></h1>
 
 <ol class="comments unstyled">
   <%= render @comments, :show_owner => true %>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -4,9 +4,7 @@
 
 <dl class="dl-horizontal">
   <dt>Gesamtzahl</dt>
-  <dd><%= User.count %></dd>
-  <dt>zuletzt synchronisiert</dt>
-  <dd><%= User.select("id", "updated_at").find_by_handle("LAST_SYNC").updated_at %></dd>
+  <dd><%= @author_count %></dd>
 </dl>
 
 <h3>Log (Letzte 50 Einträge)</h3>

--- a/test/integration/status_page_test.rb
+++ b/test/integration/status_page_test.rb
@@ -1,0 +1,8 @@
+class StatusPageTest < ActionDispatch::IntegrationTest
+
+  test 'status_page_can_be_retrieved' do
+    visit status_path
+    assert_content 'Autorendatenbank'
+  end
+
+end

--- a/test/integration/user_comment_test.rb
+++ b/test/integration/user_comment_test.rb
@@ -20,6 +20,19 @@ class UserCommentTest < ActionDispatch::IntegrationTest
     visit weekly_statuses_path
     assert_content 'pgs current status'
     assert_content 'Kommentare: 1'
+
+    visit comments_path
+    assert_content 'Alle Kommentare'
+    assert_content 'comment on pgs current status'
+
+    visit "#{comments_path}?author=guest"
+    assert_content 'Alle Kommentare von guest'
+    assert_content 'comment on pgs current status'
+  end
+
+  test 'comment by unknown author 404' do
+    get "#{comments_path}?author=rumpelstielzchen"
+    assert_equal 404, status
   end
 
   test 'entry comment creation' do


### PR DESCRIPTION
Enable us to display real names of authors.

Also move the avatar URIs to the database, rather than tying them to the author handle in a way unlikely to ever work outside of innoQ.

Updating the DB from our innoQ infrastructure is done by a `rake` task.

This needs to be triggered by `cron` or something on our production machine, lest the UI presents author handles instead of full names and the default avatar.