### PR TITLE
Authors fixup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ Please use pull requests.
 
 ### Auth
 
-iBlog will look for (and blindly trust) the `REMOTE_USER`
-HTTP header.  The content of this header is the name of the user
+iBlog will look for (and blindly trust) the `REMOTE_USER` HTTP
+header.  The content of this header is the "handle" of the user
 doing the particular request.  It is assumed that iBlog is
 deployed behind some reverse proxy that duely authenticates
 users, sets this header, and makes sure nobody from the outside
-can set it.  If a request hits iBlog without `REMOTE_USER` set, the
-hard-coded username `guest` is used, which is convenient for
+can set it.  If a request hits iBlog without `REMOTE_USER` set,
+the hard-coded username `guest` is used, which is convenient for
 local testing on a development machine.
+
+For best results, handles should consist of all lower-case
+letters.
+
+If you do use upper case letters, you are fine as long as no two
+handles differ only by case.
 
 ### Author names
 
@@ -44,15 +50,36 @@ handed in by `REMOTE_USER`) to the full author names and author
 avatar URIs.
 
 There is a rake task `authors:update` that retrieves such data
-via a JSON list, from some HTTPS-URI (or HTTP, if you must), and
-updates the database.
+via a JSON list and updates the database.  This you can use to
+sync iBlog with the avatar service database, e.g., once a day.
 
 The task expects one or three
 [task parameters](http://docs.seattlerb.org/rake/doc/rakefile_rdoc.html#label-Tasks+that+Expect+Parameters),
 namely, the URI and (if needed) the user and password required to
-access that URI.
+access that URI.  Either `file:`, `http:`, or `https:` - URIs can be used.
 
-TODO: Document the JSON.
+What is retrieved from that URI is parsed as a JSON file,
+which should have the following format:
+
+    {
+      "members": {
+        "handle1": {"displayName":"Jane Author", "avatar_scaled":"http://avatar.service.org/jane_author.jpg"},
+        "handle2": {"displayName":"Simon Shy"},
+        ...
+      }
+    }
+
+* The `members` level is mandatory.
+* Any additional information in your JSON file will be ignored, with no harm done
+  (expect using a bit of RAM for a moment).
+* Handle values should be lower-case only. As mentioned, this is the same
+  as provided in the `REMOTE_USER` header.
+* If you leave out the `avatar_scaled` field for some handle, or
+  leave out a certain handle's record alltogether, that author's avatar
+  is removed and replaced with the default one.
+
+You can find a slightly longer sample input file at
+`test/integration/update_authors_test.data`.
 
 ### Naveed
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def set_user
-    @user = request.headers['REMOTE_USER'] || 'guest'
+    user = request.headers['REMOTE_USER']
+    # MySQL does not distinguish between upper and lower case.
+    # For sanity, cast everything to lower case here.
+    # (Well... Unfortunately, this casts only in the ASCII range.)
+    @user = user.present? ? user.downcase : 'guest'
   end
 
   def set_author

--- a/test/integration/update_authors_test.data
+++ b/test/integration/update_authors_test.data
@@ -1,0 +1,23 @@
+{
+  "members": {
+    "same_guy": {
+      "displayName":"Sebastian Same",
+      "avatar_scaled": "https://example.com/sebastian_same.png"
+    },
+    "new_author": {
+      "displayName":"Anton Newauthor",
+      "avatar_scaled": "https://norbert.new.picture/blah.jpg"
+    },
+    "new_picture": {
+      "displayName":"Nadja Newpicture",
+      "avatar_scaled": "https://example.com/nadja_newpicture"
+    },
+    "no_picture": {
+      "displayName":"Simon Shy"
+    },
+    "new_name": {
+      "displayName":"Justus Justmarried",
+      "avatar_scaled": "https://lifechange.unorg/love.jpg"
+    }
+  }
+}  

--- a/test/integration/update_authors_test.rb
+++ b/test/integration/update_authors_test.rb
@@ -1,0 +1,54 @@
+require File.join(File.expand_path(File.dirname(__FILE__)), '../test_helper')
+
+class UpdateAuthorsTest < ActiveSupport::TestCase
+
+  setup do
+    @update_task = Rake::Task['authors:update']
+    # This only works when rake has been started at the root directory
+    @testfile = "file://#{@update_task.application.original_dir}/test/integration/update_authors_test.data"
+  end
+
+  def make(handle, name, uri)
+    a = Author.for_handle handle
+    a.name = name
+    a.avatar_uri = uri
+    a.save
+  end
+
+  def check(handle, name, uri)
+    a = Author.for_handle handle
+    assert_equal name, a.name
+    if uri.present?
+      assert_equal uri, a.avatar_uri, "avatar uri for handle #{handle.inspect}"
+    else
+      assert_equal uri.present?, a.avatar_uri.present?, "Avatar URI should have been absent for #{a.handle}, was #{a.avatar_uri.inspect}"
+    end
+  end
+  
+  test 'hello world' do
+
+    # Same data here and in the file, no change.
+    make 'same_guy', 'Sebastian Same', 'https://example.com/sebastian_same.png'
+
+    # No picture here, but have it in the file.
+    make 'new_picture', 'Nadja Newpicture', 'http://old.picture'
+
+    # Picture removed
+    make 'no_picture', 'Simon Shy', 'http://papparazi.org/illegal_shot.jpg'
+
+    # Name and avatar both changed
+    make 'new_name', 'Julia Single', 'http://lonely.hearts/'
+
+    # Left the company - no longer in the data at all
+    make 'no_longer', 'Lukas Nolonger', 'http://old.hands/lukas.gif'
+
+    @update_task.execute Rake::TaskArguments.new(['list_uri'], [@testfile])
+
+    check 'same_guy', 'Sebastian Same', 'https://example.com/sebastian_same.png'
+    check 'new_author', 'Anton Newauthor', 'https://norbert.new.picture/blah.jpg'
+    check 'new_picture', 'Nadja Newpicture', 'https://example.com/nadja_newpicture'
+    check 'no_picture', 'Simon Shy', nil
+    check 'no_longer', 'Lukas Nolonger', nil
+    check 'new_name', 'Justus Justmarried', 'https://lifechange.unorg/love.jpg'
+  end
+end


### PR DESCRIPTION
* Adopting the new JSON format our avatar service provides.
* Documenting that format.
* Adding tests for authors update.
* Removing avatare picture from our database if the service no longer has them.
* Improving handling of the REMOTE_USER header, which has always been handled case-insensitively, but now this is documented.

----

This pull request merges not into `master`, but into `add_authors`.

You can either just merge `add_authors` into `master`, in which case I'll rebase this to `master`.  Or else you can merge this as is, which makes pull request #205 even more fat than it presently is, and then merge that into master.

Do whatever makes it more convenient to review.