### PR TITLE
Fix Redcarpet engine options

### DIFF
--- a/app/models/concerns/markdown_extension.rb
+++ b/app/models/concerns/markdown_extension.rb
@@ -23,7 +23,7 @@ module MarkdownExtension
     # Some objects have more than one field to render as html.
     # For those, cache the markup engine.
     if @_markdown_engine.nil?
-      options = { :autolink => true, :fenced_code => true, :gh_blockcode => true }
+      options = { :autolink => true, :fenced_code_blocks => true }
       @_markdown_engine = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:hard_wrap => false), options)
     end
     @_markdown_engine.render(markdown)


### PR DESCRIPTION
The engine uses the "old" option names, created for compatibility with redcloth.
This change removes the `gh_blockcode` option, which has no effect,
and changes `fenced_code` to `fenced_code_blocks`, which is the "new" way
of specifying the same option.

Here is some sample markdown that renders correctly with this change:

	Here is a fenced code block:

	~~~
	code in a fenced block
	~~~

	And another fenced code block, which shouldn't be red:

	```
	another code block with fences
	```

	The word `ruby` should not be visible in this code block:

	```ruby
	fence ALL the code blocks!
	```