### PR TITLE
Update `redcarpet` to 3.3.4 to enable footnotes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.1.2)
-    redcarpet (2.2.2)
+    redcarpet (3.3.4)
     ref (1.0.5)
     sass (3.4.13)
     sass-rails (5.0.3)

--- a/app/models/concerns/markdown_extension.rb
+++ b/app/models/concerns/markdown_extension.rb
@@ -23,7 +23,7 @@ module MarkdownExtension
     # Some objects have more than one field to render as html.
     # For those, cache the markup engine.
     if @_markdown_engine.nil?
-      options = { :autolink => true, :fenced_code_blocks => true }
+      options = { :autolink => true, :fenced_code_blocks => true, :footnotes => true }
       @_markdown_engine = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:hard_wrap => false), options)
     end
     @_markdown_engine.render(markdown)


### PR DESCRIPTION
The bundled version of Redcarpet does not support markdown footnotes.
This change updates Redcarpet to the most recent version 3.3.4,
which includes support for footnotes, and enables that support.

This PR conflicts with #208, I’ll rebase on that when it's merged.
