### PR TITLE
Show 150 weekly status entries on page

### DIFF
--- a/app/controllers/weekly_statuses_controller.rb
+++ b/app/controllers/weekly_statuses_controller.rb
@@ -15,7 +15,7 @@
 
 class WeeklyStatusesController < ApplicationController
   def index
-    @statuses = WeeklyStatus.recent.page(params[:page])
+    @statuses = WeeklyStatus.recent.page(params[:page]).per(150)
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
By default 25 entries per page are shown, which includes the RSS feed.
Because the feed doesn't support pagination on a monday if you fetch the
feed in the evening some entries are missing. This commit introduces a
workaround by showing 150 entries per page. I tried to add pagination to
the feed but kaminari (the gem used for pagination) doesn't support
generating paginating links for ATOM feeds...

Relates to #200