### PR TITLE
Fixes the alternate link of the atom feed

### DIFF
--- a/app/views/weekly_statuses/index.atom.builder
+++ b/app/views/weekly_statuses/index.atom.builder
@@ -1,4 +1,4 @@
-atom_feed do |feed|
+atom_feed({root_url: weekly_statuses_url}) do |feed|
   feed.title "Wochenstatus"
   feed.updated @statuses.first.updated_at if @statuses.first
   feed.subtitle "weekly internal innoQ blog"

--- a/app/views/weekly_statuses/index.atom.builder
+++ b/app/views/weekly_statuses/index.atom.builder
@@ -1,4 +1,4 @@
-atom_feed({root_url: weekly_statuses_url}) do |feed|
+atom_feed(root_url: weekly_statuses_url) do |feed|
   feed.title "Wochenstatus"
   feed.updated @statuses.first.updated_at if @statuses.first
   feed.subtitle "weekly internal innoQ blog"


### PR DESCRIPTION
The feed now points to /weekly_status instead of /